### PR TITLE
[ngorm] Add DB.SingularTable

### DIFF
--- a/ngorm.go
+++ b/ngorm.go
@@ -546,3 +546,22 @@ func (db *DB) Set(key string, value interface{}) *DB {
 	db.e.Scope.Set(key, value)
 	return db
 }
+
+//SingularTable enables or diables singular tables name. By default this is
+//diables, meaning table names are in plurar.
+//
+//	Model	| Plural table name
+//	----------------------------
+//	Session	| sessions
+// 	User	| users
+//
+//	Model	| Singular table name
+//	----------------------------
+//	Session	| session
+// 	User	| user
+func (db *DB) SingularTable(enable bool) {
+	db.singularTable = enable
+	if db.e != nil {
+		db.e.SingularTable = enable
+	}
+}

--- a/ngorm_test.go
+++ b/ngorm_test.go
@@ -218,3 +218,24 @@ COMMIT;`
 		t.Errorf("expected %s got %s", expect, sql.Q)
 	}
 }
+
+func TestDB_SingularTable(t *testing.T) {
+	db, err := Open("ql-mem", "test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SingularTable(true)
+	sql, err := db.CreateSQL(&Foo{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expect := `
+BEGIN TRANSACTION;
+	INSERT INTO foo (stuff) VALUES ($1);
+COMMIT;`
+	expect = strings.TrimSpace(expect)
+	if sql.Q != expect {
+		t.Errorf("expected %s got %s", expect, sql.Q)
+	}
+}


### PR DESCRIPTION
This allows to change the way table names are derived from models. If it
is enabled(i.e set to true) the table names generated  will be in
singular form, and plural form if otherwise..

Closes #25